### PR TITLE
Small bugfixes and added display features

### DIFF
--- a/models.py
+++ b/models.py
@@ -76,7 +76,7 @@ class Header(models.Model):
     updated_at = models.DateTimeField(auto_now=True, verbose_name=_("Updated at"))
 
     identifier = models.TextField(unique=True, verbose_name=_("Identifier"))
-    timestamp = models.DateTimeField(auto_now=True, verbose_name=_("Timestamp"))
+    timestamp = models.DateTimeField(verbose_name=_("Timestamp"))
     deleted = models.BooleanField(default=False, verbose_name=_("Deleted"))
     metadata_formats = models.ManyToManyField(
         MetadataFormat,

--- a/models.py
+++ b/models.py
@@ -197,10 +197,11 @@ class DCRecord(models.Model):
             if tag_name == "identifier":
                 identifier = child.text.strip()
             else:
-                if tag_name in defaults and tag_name in ["contributor", "relation"]:
-                    defaults[tag_name] += f"\n{child.text.strip()}"
-                else:
-                    defaults[tag_name] = child.text.strip()
+                if child.text:
+                    if tag_name in defaults and tag_name in ["contributor", "relation"]:
+                        defaults[tag_name] += f"\n{child.text.strip()}"
+                    else:
+                        defaults[tag_name] = child.text.strip()
 
         if identifier is None:
             return None, False

--- a/templatetags/oai_pmh.py
+++ b/templatetags/oai_pmh.py
@@ -57,9 +57,8 @@ def admin_emails():
 @register.simple_tag
 def base_url():
     """Get OAI-PMH base url."""
-    url = settings.ALLOWED_HOSTS[0] if len(settings.ALLOWED_HOSTS) >= 1 else ""
-    return f"{url}{reverse('oai2:oai2')}"
-
+    url = settings.BASE_URL if settings.BASE_URL else ""
+    return f"{url}"
 
 @register.simple_tag
 def list_request_attributes(

--- a/templatetags/oai_pmh.py
+++ b/templatetags/oai_pmh.py
@@ -94,9 +94,9 @@ def list_request_attributes(
     if until_timestamp:
         attributes += f' until="{until_timestamp.strftime(timestamp_format)}"'
     if set_spec:
-        attributes += ' set="{escape(set_spec)}"'
+        attributes += f' set="{escape(set_spec)}"'
     if resumption_token:
-        attributes += ' resumptionToken="{escape(resumption_token)}"'
+        attributes += f' resumptionToken="{escape(resumption_token)}"'
     return mark_safe(attributes)
 
 


### PR DESCRIPTION
# What does this Pull Request do?

It fixes a problem where an XML tree child without any text would throw an exception (3aa9bf616dfabf959c25ae973b5412b2f3564eaf) and fixes two incomplete f-strings used in general info display (fff98bddc06cfe20c474b97426b799e1db5f04ad). <br>
Furthermore, a separate parameter for the repository base URL is added, which is relevant for display purposes only (826c1125d4758822815578e3655ae89841e4c8c8) and timestamps were changed to not always default to the current time during runtime (70d63b4685a75ec7937c87432780fd8326b9eda0). 

# What's new?

Several updated lines in `models.py`and `templatetags/oai_pmh.py`.